### PR TITLE
Message-hash signing

### DIFF
--- a/ckb-ledger/src/apdu.rs
+++ b/ckb-ledger/src/apdu.rs
@@ -72,3 +72,13 @@ pub fn sign_message(p1_byte: u8, vec: Vec<u8>) -> APDUCommand {
         data: vec,
     }
 }
+
+pub fn sign_message_hash(p1_byte: u8, vec: Vec<u8>) -> APDUCommand {
+    APDUCommand {
+        cla: 0x80,
+        ins: 0x07,
+        p1: p1_byte,
+        p2: 0x00,
+        data: vec,
+    }
+}

--- a/src/subcommands/util.rs
+++ b/src/subcommands/util.rs
@@ -643,7 +643,7 @@ fn sign_message(
             let key = ledger_keystore.borrow_account(&account)
                 // .and_then(|acc_cap| {acc_cap.extended_privkey(&[])})
                 .map_err(|err| err.to_string())?;
-            key.sign_message(message)
+            key.sign_message(message, None, true)
                .map_err(|err| err.to_string())
                .map(|sig| sig.serialize_compact().to_vec() )
         }


### PR DESCRIPTION
Changes to ckb-ledger to support message hash signing, and also a "ledger-sign-hash" util subcommand for the purposes of testing these changes